### PR TITLE
Fix for threadPoolExecutor leak

### DIFF
--- a/src/main/java/com/appdynamics/monitors/VMWare/VMMetricCollector.java
+++ b/src/main/java/com/appdynamics/monitors/VMWare/VMMetricCollector.java
@@ -54,7 +54,7 @@ public class VMMetricCollector extends BaseMetricCollector {
                 }
             }
         });
-
+        poolShutdownService.shutdown();
     }
 
     public void addVMs(List<VirtualMachine> virtualMachines, String baseMetricPath) {


### PR DESCRIPTION
The ThreadPoolExecutor being used by the poolShutdownService (which frees the main thread pool) was not being shutdown causing a thread leak over time.  This was causing an approx increase of 60 threads per hour based on a  1 host 1 VM monitoring configuration.  Added a shutdown call on the poolShutdownService so once it's task gets notified for hostCountDown the main executorService thread pool gets shutdown and the poolShutdownService then subsequently gets shutdown as the one and final task completes.