### PR TITLE
Fix to metric collection when VM Red

### DIFF
--- a/src/main/java/com/appdynamics/monitors/VMWare/collectors/VMMetricCollector.java
+++ b/src/main/java/com/appdynamics/monitors/VMWare/collectors/VMMetricCollector.java
@@ -45,21 +45,21 @@ public class VMMetricCollector extends BaseMetricCollector {
 
         String baseMetricName = getMetricPrefix() + "|" + "VirtualMachine" + "|" + virtualMachineName;
 
-        if (ManagedEntityStatus.red.equals(overallStatus)) {
-            logger.error("VM [{}] status is red, not collecting metrics", virtualMachineName);
-            com.appdynamics.extensions.metrics.Metric thisMetric = new com.appdynamics.extensions.metrics.Metric("status", String.valueOf(overallStatus.ordinal()), baseMetricName + "|Status");
-            getCollectedMetrics().add(thisMetric);
-            return;
-        } else {
-            com.appdynamics.extensions.metrics.Metric thisMetric = new com.appdynamics.extensions.metrics.Metric("status", String.valueOf(overallStatus.ordinal()), baseMetricName + "|Status");
-            getCollectedMetrics().add(thisMetric);
-        }
-
-        logger.info("Started collecting metrics for vm [{}]", virtualMachineName);
-
-        VirtualMachineQuickStats vmStats = virtualMachine.getSummary().getQuickStats();
-
         try {
+            if (ManagedEntityStatus.red.equals(overallStatus)) {
+                logger.error("VM [{}] status is red, not collecting metrics", virtualMachineName);
+                com.appdynamics.extensions.metrics.Metric thisMetric = new com.appdynamics.extensions.metrics.Metric("status", String.valueOf(overallStatus.ordinal()), baseMetricName + "|Status");
+                getCollectedMetrics().add(thisMetric);
+                return;
+            } else {
+                com.appdynamics.extensions.metrics.Metric thisMetric = new com.appdynamics.extensions.metrics.Metric("status", String.valueOf(overallStatus.ordinal()), baseMetricName + "|Status");
+                getCollectedMetrics().add(thisMetric);
+            }
+    
+            logger.info("Started collecting metrics for vm [{}]", virtualMachineName);
+
+            VirtualMachineQuickStats vmStats = virtualMachine.getSummary().getQuickStats();
+
             Metric[] metrics = vmMetrics.getMetrics();
 
             for (Metric metric : metrics) {


### PR DESCRIPTION
The VMMetricCollector is constructed to exit early during the metric collection
process when it detects that the VM is in a "RED" status.

The code, as previously written, will not call the
getMetricCollectorsPhaser().arriveAndDeregister() when exiting.
This in turn causes the task to never complete and write metrics to the metric
store.

To correct this, I have moved the VM status check inside the
try/catch/finally block which notifies the phaser on completion of the
task.

Ref Zendesk #269208